### PR TITLE
[JRD-343] - Refactoring to allow for better flow between CM-> IDE

### DIFF
--- a/lib/dom-file/build-dom.js
+++ b/lib/dom-file/build-dom.js
@@ -113,52 +113,33 @@ elementMethods.getChildAt = function (index) {
  * If no reference element is provided, the new element will be
  * added to the end of the list of children of the context element.
  *
- * @param {(Object|string)[]} elements - child or children to insert. may be
- *                      provided as a string, an object, or an array of objects.
+ * @param {string} element - child to insert, provided as a string.
  * @param {?Object} options - insertion options.
  * @param {?boolean} options.before - item(s) should be inserted before others.
  * @param {?boolean} options.after - item(s) should be inserted after others.
  */
-elementMethods.addChildren = function (elements, options) {
-
-    elements = _.isString(elements) ? buildDom(elements) : elements;
-
-    elements = _.isArray(elements) ? elements : [elements];
-
-    elements.forEach(function (el) {
-        if (!('uuid' in el)) {
-            el.uuid = uuid.v4();
-        }
-    });
+elementMethods.addChild = function (element, options) {
+    if (_.isString(element)) {
+        element = buildDom(element)[0];
+        element.parent = this;
+    } else {
+        throw new TypeError('Expected string, got ' + typeof element);
+    }
 
     var insertBefore = options && options.before ? options.before : false;
     var insertAfter  = options && options.after ? options.after : false;
+    var referenceIndex;
 
     if (insertBefore) {
-        elements.forEach(function (el) {
-
-            /* The referenceIndex needs to be recalculated in each addition as
-             * the index of the referenceElement will change at each insertion.
-             */
-            var referenceIndex = this._getChildIndex(insertBefore);
-
-            el.parent = this;
-            this.children.splice(referenceIndex, 0, el);
-        }, this);
+        referenceIndex = this._getChildIndex(insertBefore);
+        this.children.splice(referenceIndex, 0, element);
 
     } else if (insertAfter) {
-        var referenceIndex = this._getChildIndex(insertAfter);
-
-        elements.forEach(function (el) {
-            el.parent = this;
-            this.children.splice(referenceIndex + 1, 0, el);
-        }, this);
+        referenceIndex = this._getChildIndex(insertAfter);
+        this.children.splice(referenceIndex + 1, 0, element);
 
     } else {
-        elements.forEach(function (el) {
-            el.parent = this;
-            this.children.push(el);
-        }, this);
+        this.children.push(element);
     }
 
     var eventContent = {
@@ -167,7 +148,7 @@ elementMethods.addChildren = function (elements, options) {
 
     this.notifyUpdate(eventContent);
 
-    return this;
+    return element;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dom-fs",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/test/dom-file.js
+++ b/test/dom-file.js
@@ -1,7 +1,5 @@
 'use strict';
 require('chai').should();
-var _      = require('lodash');
-var q      = require('q');
 
 var DomFile = require('../lib/dom-file');
 
@@ -81,7 +79,7 @@ describe('DomFile', function () {
                     if (el.type === 'tag') {
 
                         if (el.getXPath() === '/html/body') {
-                            el.addChildren('<div id="lalala"></div>');
+                            el.addChild('<div id="lalala"></div>');
                         }
 
                         el.attribs['data-x-path'] = el.getXPath();
@@ -92,151 +90,5 @@ describe('DomFile', function () {
             file.write(writeOptions);
 
         });
-    });
-});
-
-describe('DomElement', function () {
-    it('.editAttribute', function () {
-        var file = new DomFile(__dirname + '/html-files/index.html');
-
-        var notified = false;
-
-        var xpath = '/html/body/h1';
-
-        var element = file.getElementByXPath(xpath);
-
-        file.on('update', function (data) {
-            data.element.uuid.should.eql(element.uuid);
-            notified = true;
-        });
-
-        element.editAttribute('data-some-attribute', 'some value');
-        element.attribs['data-some-attribute'].should.eql('some value');
-        notified.should.be.true;
-    });
-
-    it('.addChildren(element)', function () {
-        var file = new DomFile(__dirname + '/html-files/index.html');
-
-        var notified = false;
-
-        var xpath = '/html/body/div';
-
-        var element = file.getElementByXPath(xpath);
-
-        file.on('update', function (data) {
-            data.element.uuid.should.eql(element.uuid);
-            notified = true;
-        });
-
-        element.addChildren({
-            type: 'tag',
-            name: 'p',
-        });
-        _.last(element.children).should.have.ownProperty('uuid');
-        _.last(element.children).name.should.eql('p');
-        notified.should.be.true;
-    });
-
-    it('.addChildren("<div><h1>ola</h1><p>falou</p></div>")', function () {
-        var file = new DomFile(__dirname + '/html-files/index.html');
-
-        var notified = false;
-
-        var htmlString = [
-            '<div>',
-                '<h1>ola</h1>',
-                '<p>falou</p>',
-            '</div>',
-        ].join('');
-
-        var element = file.getElementByXPath('/html/body/div');
-
-        file.on('update', function (data) {
-            data.element.uuid.should.eql(element.uuid);
-            notified = true;
-        });
-
-        element.addChildren(htmlString);
-
-        var div = _.last(element.children);
-        var h1  = _.first(div.children);
-        var p   = _.last(div.children);
-
-        div.should.have.ownProperty('uuid');
-        div.name.should.eql('div');
-        h1.should.have.ownProperty('uuid');
-        h1.name.should.eql('h1');
-        p.should.have.ownProperty('uuid');
-        p.name.should.eql('p');
-        notified.should.be.true;
-    });
-
-    it('.addChildren(element, { before: referenceElement })', function (done) {
-
-        var file = new DomFile(__dirname + '/html-files/index.html');
-        var notified = false;
-
-        var refElementPromise = file.getElementByXPath('/html/body/div/h2');
-        var parElementPromise = file.getElementByXPath('/html/body/div');
-
-        q.all([refElementPromise, parElementPromise])
-            .then(function (elements) {
-
-                var parent    = elements[1];
-                var reference = elements[0];
-
-                file.on('update', function (data) {
-                    data.element.uuid.should.eql(parent.uuid);
-                    notified = true;
-                });
-
-                parent.addChildren('<div id="teste"></div>', {
-                    before: reference,
-                });
-
-                var addedElIndex = _.findIndex(parent.children, function (el) {
-                    if (el.type === 'tag') {
-                        return el.attribs.id === 'teste';
-                    }
-                });
-
-                parent.children[addedElIndex].should.have.ownProperty('uuid');
-                addedElIndex.should.eql(parent._getChildIndex(reference) - 1);
-                notified.should.be.true;
-
-                done();
-            })
-            .done();
-    });
-
-    it('.addChildren(elements, { after: referenceElement })', function () {
-        var file = new DomFile(__dirname + '/html-files/index.html');
-        var notified = false;
-
-        var parent = file.getElementByXPath('/html/body/div');
-        var reference = file.getElementByXPath('/html/body/div/h1');
-
-        file.on('update', function (data) {
-            data.element.uuid.should.eql(parent.uuid);
-            notified = true;
-        });
-
-        parent.addChildren('<a id="teste"></a>', {
-            after: reference,
-        });
-
-        var addedElementIndex = _.findIndex(parent.children, function (el) {
-            if (el.type === 'tag') {
-                return el.attribs.id === 'teste';
-            }
-        });
-
-        parent.children[addedElementIndex].should.have.ownProperty('uuid');
-        addedElementIndex.should.eql(parent._getChildIndex(reference) + 1);
-        notified.should.be.true;
-    });
-
-    it('.removeChildren(elements)', function () {
     });
 });

--- a/test/dom-fs.js
+++ b/test/dom-fs.js
@@ -43,6 +43,6 @@ describe('DomFs', function () {
             done();
         });
 
-        element.addChildren({type: 'tag', name: 'p'});
+        element.addChild('<div></div>');
     });
 });


### PR DESCRIPTION
Refactored addChildren to addChild: now only accepts one element to
insert, and only as a string. Throws TypeError if other type is
provided. Returns the newly created element.
Removed duplicate tests.
